### PR TITLE
Add custom Test page to sidebar navigation

### DIFF
--- a/app/Http/Controllers/TestPageController.php
+++ b/app/Http/Controllers/TestPageController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Contracts\View\View;
+
+class TestPageController extends Controller
+{
+    /**
+     * Display the custom test page.
+     */
+    public function __invoke(): View
+    {
+        return view('custom.test');
+    }
+}

--- a/resources/views/custom/test.blade.php
+++ b/resources/views/custom/test.blade.php
@@ -1,0 +1,21 @@
+@extends('layouts/default')
+
+@section('title')
+Test
+@parent
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-md-12">
+        <div class="box">
+            <div class="box-header with-border">
+                <h3 class="box-title">Test</h3>
+            </div>
+            <div class="box-body">
+                <p>This is a custom test page.</p>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -460,6 +460,12 @@ dir="{{ Helper::determineLanguageDirection() }}">
                                 </a>
                             </li>
                         @endcan
+                        <li{!! (request()->is('test') ? ' class="active"' : '') !!}>
+                            <a href="{{ route('custom.test') }}">
+                                <x-icon type="files" class="fa-fw" />
+                                <span>Test</span>
+                            </a>
+                        </li>
                         @can('index', \App\Models\Asset::class)
                             <li class="treeview{{ ((request()->is('statuslabels/*') || request()->is('hardware*')) ? ' active' : '') }}">
                                 <a href="#">

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\ReportsController;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\StatuslabelsController;
 use App\Http\Controllers\SuppliersController;
+use App\Http\Controllers\TestPageController;
 use App\Http\Controllers\ViewAssetsController;
 use App\Livewire\Importer;
 use App\Models\ReportTemplate;
@@ -30,6 +31,9 @@ use Illuminate\Support\Facades\Route;
 use Tabuna\Breadcrumbs\Trail;
 
 Route::group(['middleware' => 'auth'], function () {
+    Route::get('test', TestPageController::class)
+        ->name('custom.test');
+
     /*
     * Companies
     */


### PR DESCRIPTION
## Summary
- add a dedicated controller and Blade view for a custom Test page
- register an authenticated route for the page and surface it from the sidebar navigation

## Testing
- composer dump-autoload *(fails: Class "Illuminate\\Foundation\\Application" not found during artisan package discovery)*

------
https://chatgpt.com/codex/tasks/task_e_68de4912e328832088733472e6d18baa