### PR TITLE
Add Intune sync preview workflow to test page

### DIFF
--- a/app/Http/Controllers/TestPageController.php
+++ b/app/Http/Controllers/TestPageController.php
@@ -2,15 +2,61 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\IntuneSyncService;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 
 class TestPageController extends Controller
 {
     /**
      * Display the custom test page.
      */
-    public function __invoke(): View
+    public function index(Request $request): View
     {
-        return view('custom.test');
+        return view('custom.test', [
+            'syncResults' => $request->session()->get('intune_sync_results'),
+            'selectionSummary' => $request->session()->get('intune_sync_selection'),
+        ]);
+    }
+
+    /**
+     * Execute a preview synchronisation with Intune and store the results in the session.
+     */
+    public function sync(Request $request, IntuneSyncService $service): RedirectResponse
+    {
+        $results = $service->preview();
+
+        $request->session()->put('intune_sync_results', $results);
+        $request->session()->forget('intune_sync_selection');
+
+        return redirect()->route('custom.test')->with('status', __('Sincronizzazione Intune completata.')); // @codeCoverageIgnore
+    }
+
+    /**
+     * Persist the user decision about which devices should be created or updated.
+     */
+    public function applySelection(Request $request): RedirectResponse
+    {
+        $results = $request->session()->get('intune_sync_results');
+
+        if (! $results) {
+            return redirect()->route('custom.test')->withErrors([
+                'intune' => __('Esegui prima una sincronizzazione con Intune per ottenere dei risultati.'),
+            ]);
+        }
+
+        $newDevices = collect($results['new_devices'] ?? []);
+        $updatedDevices = collect($results['updated_devices'] ?? []);
+
+        $selectedAdds = $newDevices->whereIn('identifier', $request->input('add', []))->values()->all();
+        $selectedUpdates = $updatedDevices->whereIn('identifier', $request->input('update', []))->values()->all();
+
+        $request->session()->put('intune_sync_selection', [
+            'adds' => $selectedAdds,
+            'updates' => $selectedUpdates,
+        ]);
+
+        return redirect()->route('custom.test')->with('status', __('Selezione dispositivi salvata.'));
     }
 }

--- a/app/Services/IntuneSyncService.php
+++ b/app/Services/IntuneSyncService.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Asset;
+
+class IntuneSyncService
+{
+    /**
+     * Build a preview of the differences between Intune devices and the current assets.
+     */
+    public function preview(): array
+    {
+        $intuneDevices = collect(config('intune.devices', []))
+            ->map(fn (array $device) => $this->normaliseDevice($device));
+
+        $existingAssets = Asset::query()
+            ->select(['id', 'name', 'asset_tag', 'serial'])
+            ->whereNotNull('serial')
+            ->get()
+            ->keyBy('serial')
+            ->map(fn (Asset $asset) => [
+                'id' => $asset->id,
+                'name' => $asset->name,
+                'asset_tag' => $asset->asset_tag,
+                'serial' => $asset->serial,
+            ]);
+
+        $newDevices = [];
+        $updatedDevices = [];
+
+        foreach ($intuneDevices as $device) {
+            $existing = $device['serial']
+                ? $existingAssets->get($device['serial'])
+                : null;
+
+            if (! $existing) {
+                $newDevices[] = $device;
+
+                continue;
+            }
+
+            $differences = $this->diffAgainstExisting($device, $existing);
+
+            if (! empty($differences)) {
+                $updatedDevices[] = array_merge($device, [
+                    'existing' => $existing,
+                    'differences' => $differences,
+                ]);
+            }
+        }
+
+        return [
+            'generated_at' => now()->toDateTimeString(),
+            'source_count' => $intuneDevices->count(),
+            'new_devices' => $newDevices,
+            'updated_devices' => $updatedDevices,
+        ];
+    }
+
+    /**
+     * Normalise the Intune payload to a consistent structure.
+     */
+    private function normaliseDevice(array $device): array
+    {
+        $serial = $device['serial']
+            ?? $device['serialNumber']
+            ?? null;
+
+        return [
+            'identifier' => $serial
+                ?? $device['id']
+                ?? md5(json_encode($device)),
+            'id' => $device['id'] ?? null,
+            'display_name' => $device['name']
+                ?? $device['displayName']
+                ?? __('Dispositivo senza nome'),
+            'asset_tag' => $device['asset_tag'] ?? null,
+            'serial' => $serial,
+            'model' => $device['model'] ?? null,
+            'user' => $device['user'] ?? $device['primaryUser'] ?? null,
+            'last_sync' => $device['last_sync'] ?? $device['lastSyncDateTime'] ?? null,
+            'raw' => $device,
+        ];
+    }
+
+    /**
+     * Determine what has changed between the local asset and the Intune device.
+     */
+    private function diffAgainstExisting(array $device, array $existing): array
+    {
+        $differences = [];
+
+        if (($existing['name'] ?? null) !== ($device['display_name'] ?? null)) {
+            $differences['name'] = [
+                'current' => $existing['name'] ?? null,
+                'incoming' => $device['display_name'] ?? null,
+            ];
+        }
+
+        if (($existing['asset_tag'] ?? null) !== ($device['asset_tag'] ?? null)) {
+            $differences['asset_tag'] = [
+                'current' => $existing['asset_tag'] ?? null,
+                'incoming' => $device['asset_tag'] ?? null,
+            ];
+        }
+
+        return $differences;
+    }
+}

--- a/config/intune.php
+++ b/config/intune.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Dispositivi Intune di esempio
+    |--------------------------------------------------------------------------
+    |
+    | Questi dati vengono utilizzati come esempio per illustrare il flusso
+    | della sincronizzazione dalla pagina di test. Sostituiscili con una
+    | chiamata reale a Microsoft Graph oppure popola questo array con i dati
+    | provenienti dal tuo tenant Intune.
+    |
+    */
+
+    'devices' => [
+        [
+            'id' => 'intune-001',
+            'name' => 'PC-Ufficio-01',
+            'asset_tag' => 'PC-0001',
+            'serial' => 'INTUNE-SN-001',
+            'model' => 'Lenovo ThinkPad L14',
+            'user' => 'marco.rossi',
+            'last_sync' => '2024-03-15T09:30:00+00:00',
+        ],
+        [
+            'id' => 'intune-002',
+            'name' => 'PC-Ufficio-02',
+            'asset_tag' => 'PC-0002',
+            'serial' => 'INTUNE-SN-002',
+            'model' => 'HP EliteBook 840',
+            'user' => 'laura.bianchi',
+            'last_sync' => '2024-03-14T17:05:00+00:00',
+        ],
+        [
+            'id' => 'intune-003',
+            'name' => 'Portatile-TeamVendite',
+            'asset_tag' => 'PC-0105',
+            'serial' => 'INTUNE-SN-003',
+            'model' => 'Dell XPS 13',
+            'user' => 'sales.team',
+            'last_sync' => '2024-03-16T12:20:00+00:00',
+        ],
+    ],
+];

--- a/resources/views/custom/test.blade.php
+++ b/resources/views/custom/test.blade.php
@@ -13,7 +13,152 @@ Test
                 <h3 class="box-title">Test</h3>
             </div>
             <div class="box-body">
-                <p>This is a custom test page.</p>
+                @if (session('status'))
+                    <div class="alert alert-success alert-dismissable">
+                        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+                        {{ session('status') }}
+                    </div>
+                @endif
+
+                @if ($errors->has('intune'))
+                    <div class="alert alert-danger alert-dismissable">
+                        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+                        {{ $errors->first('intune') }}
+                    </div>
+                @endif
+
+                <p class="text-muted">
+                    In questa pagina di test puoi avviare una sincronizzazione manuale con Microsoft Intune.
+                    Dopo l'analisi ti verranno proposti i dispositivi da aggiungere e quelli da aggiornare,
+                    lasciandoti la libertà di scegliere come procedere.
+                </p>
+
+                <form method="POST" action="{{ route('custom.test.sync') }}" class="form-inline">
+                    @csrf
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa fa-sync"></i> Avvia sincronizzazione con Intune
+                    </button>
+                </form>
+
+                @if (! empty($syncResults))
+                    <hr>
+                    <h4>Risultati dell'ultima sincronizzazione</h4>
+                    <p class="text-muted">
+                        Generato il {{ $syncResults['generated_at'] ?? '' }}
+                        ({{ $syncResults['source_count'] ?? 0 }} dispositivi analizzati).
+                    </p>
+
+                    <form method="POST" action="{{ route('custom.test.apply') }}">
+                        @csrf
+
+                        <h5>Nuovi dispositivi proposti</h5>
+                        @if (! empty($syncResults['new_devices']))
+                            <div class="list-group">
+                                @foreach ($syncResults['new_devices'] as $device)
+                                    <label class="list-group-item">
+                                        <input type="checkbox" name="add[]" value="{{ $device['identifier'] }}" style="margin-right: 8px;" checked>
+                                        <strong>{{ $device['display_name'] }}</strong>
+                                        <span class="text-muted">
+                                            @if (! empty($device['serial']))
+                                                · Seriale: {{ $device['serial'] }}
+                                            @endif
+                                            @if (! empty($device['asset_tag']))
+                                                · Asset tag: {{ $device['asset_tag'] }}
+                                            @endif
+                                            @if (! empty($device['model']))
+                                                · Modello: {{ $device['model'] }}
+                                            @endif
+                                            @if (! empty($device['user']))
+                                                · Utente: {{ $device['user'] }}
+                                            @endif
+                                        </span>
+                                    </label>
+                                @endforeach
+                            </div>
+                        @else
+                            <p class="text-muted">Nessun nuovo dispositivo da aggiungere.</p>
+                        @endif
+
+                        <h5 style="margin-top: 20px;">Dispositivi esistenti con differenze</h5>
+                        @if (! empty($syncResults['updated_devices']))
+                            <div class="list-group">
+                                @foreach ($syncResults['updated_devices'] as $device)
+                                    <div class="list-group-item">
+                                        <label>
+                                            <input type="checkbox" name="update[]" value="{{ $device['identifier'] }}" style="margin-right: 8px;" checked>
+                                            <strong>{{ $device['display_name'] }}</strong>
+                                        </label>
+                                        <div class="small text-muted" style="margin-top: 8px;">
+                                            @foreach ($device['differences'] as $field => $diff)
+                                                <div>
+                                                    <strong>{{ $field === 'asset_tag' ? 'Asset tag' : 'Nome' }}:</strong>
+                                                    <span>attuale <code>{{ $diff['current'] ?? '—' }}</code></span>
+                                                    <span>→ Intune <code>{{ $diff['incoming'] ?? '—' }}</code></span>
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                        @if (! empty($device['existing']['id']))
+                                            <p class="small text-muted" style="margin-top: 6px;">
+                                                Asset Snipe-IT collegato #{{ $device['existing']['id'] }}
+                                            </p>
+                                        @endif
+                                    </div>
+                                @endforeach
+                            </div>
+                        @else
+                            <p class="text-muted">Nessun dispositivo esistente richiede modifiche.</p>
+                        @endif
+
+                        <button type="submit" class="btn btn-success" style="margin-top: 20px;">
+                            <i class="fa fa-save"></i> Salva la selezione
+                        </button>
+                    </form>
+                @endif
+
+                @if (! empty($selectionSummary))
+                    <hr>
+                    <h4>Ultima scelta salvata</h4>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <h5>Da aggiungere</h5>
+                            @if (! empty($selectionSummary['adds']))
+                                <ul class="list-unstyled">
+                                    @foreach ($selectionSummary['adds'] as $device)
+                                        <li>
+                                            <strong>{{ $device['display_name'] }}</strong>
+                                            @if (! empty($device['serial']))
+                                                <span class="text-muted">(Seriale: {{ $device['serial'] }})</span>
+                                            @endif
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            @else
+                                <p class="text-muted">Nessun nuovo dispositivo selezionato.</p>
+                            @endif
+                        </div>
+                        <div class="col-md-6">
+                            <h5>Da aggiornare</h5>
+                            @if (! empty($selectionSummary['updates']))
+                                <ul class="list-unstyled">
+                                    @foreach ($selectionSummary['updates'] as $device)
+                                        <li>
+                                            <strong>{{ $device['display_name'] }}</strong>
+                                            @if (! empty($device['differences']))
+                                                <ul class="list-unstyled small text-muted">
+                                                    @foreach ($device['differences'] as $field => $diff)
+                                                        <li>{{ $field === 'asset_tag' ? 'Asset tag' : 'Nome' }}: {{ $diff['current'] ?? '—' }} → {{ $diff['incoming'] ?? '—' }}</li>
+                                                    @endforeach
+                                                </ul>
+                                            @endif
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            @else
+                                <p class="text-muted">Nessun aggiornamento selezionato.</p>
+                            @endif
+                        </div>
+                    </div>
+                @endif
             </div>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,8 +31,14 @@ use Illuminate\Support\Facades\Route;
 use Tabuna\Breadcrumbs\Trail;
 
 Route::group(['middleware' => 'auth'], function () {
-    Route::get('test', TestPageController::class)
+    Route::get('test', [TestPageController::class, 'index'])
         ->name('custom.test');
+
+    Route::post('test/intune-sync', [TestPageController::class, 'sync'])
+        ->name('custom.test.sync');
+
+    Route::post('test/intune-sync/apply', [TestPageController::class, 'applySelection'])
+        ->name('custom.test.apply');
 
     /*
     * Companies


### PR DESCRIPTION
## Summary
- replace the test page with an Intune sync preview workflow that lets admins review proposed additions and updates
- add an IntuneSyncService to diff Intune devices against existing Snipe-IT assets
- provide sample Intune device data in a dedicated config file for demo/testing purposes

## Testing
- php -l app/Http/Controllers/TestPageController.php
- php -l app/Services/IntuneSyncService.php
- php -l config/intune.php

------
https://chatgpt.com/codex/tasks/task_e_68df7ca697188320adc94b4f966730e0