### PR TITLE
Add Intune sync settings configuration UI

### DIFF
--- a/app/Http/Controllers/TestPageController.php
+++ b/app/Http/Controllers/TestPageController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Services\IntuneSyncService;
+use App\Support\IntuneSettings;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -17,6 +18,7 @@ class TestPageController extends Controller
         return view('custom.test', [
             'syncResults' => $request->session()->get('intune_sync_results'),
             'selectionSummary' => $request->session()->get('intune_sync_selection'),
+            'intuneSettings' => IntuneSettings::get(),
         ]);
     }
 
@@ -58,5 +60,34 @@ class TestPageController extends Controller
         ]);
 
         return redirect()->route('custom.test')->with('status', __('Selezione dispositivi salvata.'));
+    }
+
+    /**
+     * Show the configuration page for Intune synchronisation settings.
+     */
+    public function settings(): View
+    {
+        return view('custom.test-settings', [
+            'settings' => IntuneSettings::get(),
+        ]);
+    }
+
+    /**
+     * Persist the Intune synchronisation settings provided by the user.
+     */
+    public function updateSettings(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'tenant_domain' => ['required', 'string', 'max:255'],
+            'application_id' => ['nullable', 'string', 'max:255'],
+            'client_secret' => ['nullable', 'string', 'max:255'],
+            'device_filter' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        IntuneSettings::update($validated);
+
+        return redirect()
+            ->route('custom.test.settings')
+            ->with('status', __('Impostazioni Intune aggiornate con successo.'));
     }
 }

--- a/app/Support/IntuneSettings.php
+++ b/app/Support/IntuneSettings.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
+
+class IntuneSettings
+{
+    /**
+     * Location of the stored Intune settings.
+     */
+    private const STORAGE_PATH = 'intune-settings.json';
+
+    /**
+     * Retrieve the current Intune settings.
+     */
+    public static function get(): array
+    {
+        if (! Storage::disk('local')->exists(self::STORAGE_PATH)) {
+            return self::defaults();
+        }
+
+        $decoded = json_decode(Storage::disk('local')->get(self::STORAGE_PATH), true);
+
+        if (! is_array($decoded)) {
+            return self::defaults();
+        }
+
+        return array_merge(self::defaults(), $decoded);
+    }
+
+    /**
+     * Persist the provided Intune settings.
+     */
+    public static function update(array $settings): void
+    {
+        $payload = array_merge(self::defaults(), Arr::only($settings, array_keys(self::defaults())));
+
+        Storage::disk('local')->put(
+            self::STORAGE_PATH,
+            json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    /**
+     * Default values for the Intune settings.
+     */
+    private static function defaults(): array
+    {
+        return [
+            'tenant_domain' => '',
+            'application_id' => '',
+            'client_secret' => '',
+            'device_filter' => '',
+        ];
+    }
+}

--- a/resources/views/custom/test-settings.blade.php
+++ b/resources/views/custom/test-settings.blade.php
@@ -1,0 +1,99 @@
+@extends('layouts/default')
+
+@section('title')
+    Configurazione Intune
+    @parent
+@stop
+
+@section('content')
+    <div class="row">
+        <div class="col-md-12">
+            <div class="box">
+                <div class="box-header with-border">
+                    <h3 class="box-title">Configurazione sincronizzazione Intune</h3>
+                </div>
+                <div class="box-body">
+                    <p class="text-muted">
+                        Definisci i parametri necessari per collegare Snipe-IT al tenant Intune del tuo dominio.
+                        Queste impostazioni verranno utilizzate durante la sincronizzazione dalla pagina di test.
+                    </p>
+
+                    @if (session('status'))
+                        <div class="alert alert-success alert-dismissable">
+                            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+                            {{ session('status') }}
+                        </div>
+                    @endif
+
+                    @if ($errors->any())
+                        <div class="alert alert-danger alert-dismissable">
+                            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
+                            <ul class="list-unstyled" style="margin: 0;">
+                                @foreach ($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    <form method="POST" action="{{ route('custom.test.settings.update') }}" class="form-horizontal">
+                        @csrf
+
+                        <div class="form-group {{ $errors->has('tenant_domain') ? 'has-error' : '' }}">
+                            <label for="tenant_domain" class="col-md-3 control-label">Dominio Intune *</label>
+                            <div class="col-md-6">
+                                <input type="text" name="tenant_domain" id="tenant_domain" value="{{ old('tenant_domain', $settings['tenant_domain'] ?? '') }}" class="form-control" required>
+                                <p class="help-block">Esempio: contoso.onmicrosoft.com</p>
+                                @if ($errors->has('tenant_domain'))
+                                    <span class="help-block">{{ $errors->first('tenant_domain') }}</span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group {{ $errors->has('application_id') ? 'has-error' : '' }}">
+                            <label for="application_id" class="col-md-3 control-label">ID applicazione (client)</label>
+                            <div class="col-md-6">
+                                <input type="text" name="application_id" id="application_id" value="{{ old('application_id', $settings['application_id'] ?? '') }}" class="form-control">
+                                <p class="help-block">L'ID dell'app registrata in Azure AD che eseguirà la sincronizzazione.</p>
+                                @if ($errors->has('application_id'))
+                                    <span class="help-block">{{ $errors->first('application_id') }}</span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group {{ $errors->has('client_secret') ? 'has-error' : '' }}">
+                            <label for="client_secret" class="col-md-3 control-label">Client secret</label>
+                            <div class="col-md-6">
+                                <input type="text" name="client_secret" id="client_secret" value="{{ old('client_secret', $settings['client_secret'] ?? '') }}" class="form-control">
+                                <p class="help-block">Segreto associato all'applicazione per autenticarsi su Microsoft Graph.</p>
+                                @if ($errors->has('client_secret'))
+                                    <span class="help-block">{{ $errors->first('client_secret') }}</span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group {{ $errors->has('device_filter') ? 'has-error' : '' }}">
+                            <label for="device_filter" class="col-md-3 control-label">Filtro dispositivi</label>
+                            <div class="col-md-6">
+                                <input type="text" name="device_filter" id="device_filter" value="{{ old('device_filter', $settings['device_filter'] ?? '') }}" class="form-control">
+                                <p class="help-block">Facoltativo: specifica un gruppo o tag Intune da sincronizzare.</p>
+                                @if ($errors->has('device_filter'))
+                                    <span class="help-block">{{ $errors->first('device_filter') }}</span>
+                                @endif
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="col-md-offset-3 col-md-6">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fa fa-save"></i> Salva impostazioni
+                                </button>
+                                <a href="{{ route('custom.test') }}" class="btn btn-link">Torna alla pagina di test</a>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/custom/test.blade.php
+++ b/resources/views/custom/test.blade.php
@@ -11,6 +11,11 @@ Test
         <div class="box">
             <div class="box-header with-border">
                 <h3 class="box-title">Test</h3>
+                <div class="box-tools pull-right">
+                    <a href="{{ route('custom.test.settings') }}" class="btn btn-default btn-sm">
+                        <i class="fa fa-cog"></i> Configura sincronizzazione Intune
+                    </a>
+                </div>
             </div>
             <div class="box-body">
                 @if (session('status'))
@@ -24,6 +29,16 @@ Test
                     <div class="alert alert-danger alert-dismissable">
                         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>
                         {{ $errors->first('intune') }}
+                    </div>
+                @endif
+
+                @if (! empty($intuneSettings['tenant_domain']) || ! empty($intuneSettings['device_filter']))
+                    <div class="alert alert-info" style="margin-bottom: 20px;">
+                        <strong>Configurazione corrente:</strong>
+                        <span>Dominio {{ $intuneSettings['tenant_domain'] ?: 'non impostato' }}</span>
+                        @if (! empty($intuneSettings['device_filter']))
+                            <span>· Filtro dispositivi: {{ $intuneSettings['device_filter'] }}</span>
+                        @endif
                     </div>
                 @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,6 +40,12 @@ Route::group(['middleware' => 'auth'], function () {
     Route::post('test/intune-sync/apply', [TestPageController::class, 'applySelection'])
         ->name('custom.test.apply');
 
+    Route::get('test/settings', [TestPageController::class, 'settings'])
+        ->name('custom.test.settings');
+
+    Route::post('test/settings', [TestPageController::class, 'updateSettings'])
+        ->name('custom.test.settings.update');
+
     /*
     * Companies
     */


### PR DESCRIPTION
## Summary
- add a configuration entry point to the Intune test page and surface the current settings
- implement persistent storage for Intune synchronisation parameters and provide a dedicated form
- register routes and controller actions for viewing and updating the Intune settings

## Testing
- php artisan test --testsuite=Unit *(fails: vendor directory is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df7e5be5c8832099e1ea702ea6037b