### PR TITLE
Add configurable Intune asset column mapping

### DIFF
--- a/app/Support/IntuneSettings.php
+++ b/app/Support/IntuneSettings.php
@@ -4,6 +4,7 @@ namespace App\Support;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class IntuneSettings
 {
@@ -17,17 +18,26 @@ class IntuneSettings
      */
     public static function get(): array
     {
+        $defaults = self::defaults();
+
         if (! Storage::disk('local')->exists(self::STORAGE_PATH)) {
-            return self::defaults();
+            return $defaults;
         }
 
         $decoded = json_decode(Storage::disk('local')->get(self::STORAGE_PATH), true);
 
         if (! is_array($decoded)) {
-            return self::defaults();
+            return $defaults;
         }
 
-        return array_merge(self::defaults(), $decoded);
+        if (isset($decoded['asset_column_map']) && is_array($decoded['asset_column_map'])) {
+            $decoded['asset_column_map'] = array_merge(
+                $defaults['asset_column_map'],
+                Arr::only($decoded['asset_column_map'], array_keys($defaults['asset_column_map']))
+            );
+        }
+
+        return array_merge($defaults, $decoded);
     }
 
     /**
@@ -35,7 +45,24 @@ class IntuneSettings
      */
     public static function update(array $settings): void
     {
-        $payload = array_merge(self::defaults(), Arr::only($settings, array_keys(self::defaults())));
+        $defaults = self::defaults();
+
+        $payload = $defaults;
+
+        foreach (Arr::only($settings, array_keys($defaults)) as $key => $value) {
+            if ($key === 'asset_column_map') {
+                if (is_array($value)) {
+                    $payload[$key] = array_merge(
+                        $defaults[$key],
+                        Arr::only($value, array_keys($defaults[$key]))
+                    );
+                }
+
+                continue;
+            }
+
+            $payload[$key] = $value;
+        }
 
         Storage::disk('local')->put(
             self::STORAGE_PATH,
@@ -53,6 +80,55 @@ class IntuneSettings
             'application_id' => '',
             'client_secret' => '',
             'device_filter' => '',
+            'asset_column_map' => [
+                'asset_tag' => 'asset_tag',
+                'serial' => 'serial',
+                'name' => 'display_name',
+            ],
         ];
+    }
+
+    /**
+     * Labels for the asset columns that can be mapped to Intune fields.
+     */
+    public static function assetColumnLabels(): array
+    {
+        return [
+            'asset_tag' => __('Tag asset'),
+            'serial' => __('Numero di serie'),
+            'name' => __('Nome asset'),
+        ];
+    }
+
+    /**
+     * Available Intune columns that can be mapped to asset columns.
+     */
+    public static function intuneColumnOptions(): array
+    {
+        $columns = collect(config('intune.devices', []))
+            ->flatMap(fn (array $device) => array_keys($device))
+            ->merge([
+                'asset_tag',
+                'display_name',
+                'displayName',
+                'id',
+                'last_sync',
+                'lastSyncDateTime',
+                'model',
+                'name',
+                'primaryUser',
+                'serial',
+                'serialNumber',
+                'user',
+            ])
+            ->unique()
+            ->sort()
+            ->values();
+
+        return $columns->mapWithKeys(function ($column) {
+            $label = Str::headline(str_replace('_', ' ', $column));
+
+            return [$column => $label];
+        })->all();
     }
 }

--- a/resources/views/custom/test-settings.blade.php
+++ b/resources/views/custom/test-settings.blade.php
@@ -85,6 +85,37 @@
 
                         <div class="form-group">
                             <div class="col-md-offset-3 col-md-6">
+                                <hr>
+                                <h4 style="margin-top: 0;">Mappatura colonne asset</h4>
+                                <p class="text-muted" style="margin-bottom: 20px;">
+                                    Associa ogni colonna degli asset di Snipe-IT al campo corrispondente di Intune da utilizzare durante la sincronizzazione.
+                                </p>
+                            </div>
+                        </div>
+
+                        @foreach ($assetColumns as $column => $label)
+                            @php($fieldError = $errors->has("asset_column_map.$column"))
+                            <div class="form-group {{ $fieldError ? 'has-error' : '' }}">
+                                <label class="col-md-3 control-label">{{ $label }}</label>
+                                <div class="col-md-6">
+                                    <select name="asset_column_map[{{ $column }}]" class="form-control">
+                                        <option value="">— Nessun campo —</option>
+                                        @foreach ($intuneColumns as $intuneKey => $intuneLabel)
+                                            <option value="{{ $intuneKey }}" @selected(old("asset_column_map.$column", $settings['asset_column_map'][$column] ?? '') === $intuneKey)>
+                                                {{ $intuneLabel }} ({{ $intuneKey }})
+                                            </option>
+                                        @endforeach
+                                    </select>
+
+                                    @if ($fieldError)
+                                        <span class="help-block">{{ $errors->first("asset_column_map.$column") }}</span>
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+
+                        <div class="form-group">
+                            <div class="col-md-offset-3 col-md-6">
                                 <button type="submit" class="btn btn-primary">
                                     <i class="fa fa-save"></i> Salva impostazioni
                                 </button>


### PR DESCRIPTION
## Summary
- add defaults and helpers for asset-to-Intune column mappings in the Intune settings store
- validate and persist the selected column mapping when saving Intune configuration
- present dropdowns on the Intune settings page to map Snipe-IT asset columns to Intune device fields

## Testing
- php -l app/Support/IntuneSettings.php
- php -l app/Http/Controllers/TestPageController.php

------
https://chatgpt.com/codex/tasks/task_e_68df7fd5ec248320a22a32a47cf07494